### PR TITLE
revised test prep title; added NGSS tags; title documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - `ost-*`: Only OST cares about
   - `ost-tag-*`
     - `ost-tag-lo-*`: ie `ost-tag-lo-k12phys-ch12-s01-lo04` use k12phys to distinguish from college physics
+    - `ost-tag-ngss-k12phys-*`: ie `ost-tag-ngss-k12phys-hs-ps2-1`
     - `ost-tag-blooms-*`: ie `ost-tag-blooms-1`
     - `ost-tag-teks-*`: ie `ost-tag-teks-112-39-c-4c`
     - `ost-tag-dok-*`: ie `ost-tag-dok-1`
@@ -33,6 +34,7 @@
   - `ost-assignable`: Only on `snap-lab`s. 
   - `ost-teks-def` : Place on the text of the TEKS in teacher-content that tells what that TEKS addresses
   - `ost-learning-objective-def` : Place on the learning objective text that defines the LO 
+  - `ost-ngss-def` : Place on the Next Generation Science Standards (NGSS) text that defines the NGSS. Only occurs on Performance Task.
 - no prefix: visual styling only
 
 
@@ -257,6 +259,15 @@ Notes:
 
 ### Special classes within teacher content
 
+####Teacher Content with NGSS tag
+
+```html
+
+ <note class="os-teacher">
+  <label>Teacher Edition</label>
+  <p>NGSS HS-PS2-1: Students who demonstrate understanding can: <span class="ost-tag-ngss-k12phys-hs-ps2-1 ost-ngss-def">Analyze data to support the claim that Newton’s second law of motion describes the mathematical relationship among the net force on a macroscopic object, its mass, and its acceleration</span>.</p> 
+</note>
+
 ####Teacher Misconception Alert
 
 ```html
@@ -333,7 +344,7 @@ Practice problems occur after worked examples within the flow of the section con
 
 ### Chapter Review 
 
-**Note:** `chapter-review` has several different variants: `concept` `problem` `critical-thinking` `performance`
+**Note:** `chapter-review` has several different variants: `concept` `problem` `critical-thinking` `performance` . Because the title Chapter Review does not make sense in the context of a module on web view, do not add Chapter Review to the <title> tag for chapter-review elements. However, Chapter Review will be added as a header to the PDF when the items are collated from multiple sections, as required by the Design Template.
 
 ```html
 <section class="ost-reading-discard chapter-review concept">
@@ -352,10 +363,10 @@ Practice problems occur after worked examples within the flow of the section con
 ```
 ### Chapter Review Performance Task
 
-**Note:** `chapter-review-performance` is discarded from Tutor's i-reading and can be assigned as a separate step (similar to Snap Labs). 
+**Note:** `chapter-review performance` is discarded from Tutor's i-reading and can be assigned as a separate step (similar to Snap Labs). 
 
 ```html
-<section class="ost-reading-discard ost-assignable chapter-review performance">
+<section class="ost-reading-discard ost-assignable chapter-review performance ost-tag-ngss-k12phys-*">
   <title>Performance Task</title>
   <exercise class="os-exercise">
     <problem>
@@ -366,11 +377,11 @@ Practice problems occur after worked examples within the flow of the section con
 
 ### Test Prep
 
-**Note:** `test-prep` has several different variants : `multiple-choice` `short-answer` `extended-response`
+**Note:** `test-prep` has several different variants : `multiple-choice` `short-answer` `extended-response` The <title> tag must include Test Prep so that the full title appears in Web View. The PDF will overwrite this title to replace “Test Prep Extended Response” with “Extended Response” as required by the Design Template.
 
 ```html
 <section class="ost-reading-discard test-prep multiple-choice">
-  <title>Multiple Choice</title>
+  <title>Test Prep Multiple Choice</title>
   <exercise class="os-exercise">
     <problem>
       <para><a class="os-embed" href="..." /></para>

--- a/README.md
+++ b/README.md
@@ -263,9 +263,10 @@ Notes:
 
 ```html
 
- <note class="os-teacher">
+<note class="os-teacher">
   <label>Teacher Edition</label>
-  <p>NGSS HS-PS2-1: Students who demonstrate understanding can: <span class="ost-tag-ngss-k12phys-hs-ps2-1 ost-ngss-def">Analyze data to support the claim that Newton’s second law of motion describes the mathematical relationship among the net force on a macroscopic object, its mass, and its acceleration</span>.</p> 
+  <p>NGSS HS-PS2-1:<span class="ost-tag-ngss-k12phys-hs-ps2-1 ost-ngss-def">Students who demonstrate understanding can: Analyze
+  data to support the claim that Newton’s second law of motion describes the mathematical relationship among the net force on a   macroscopic object, its mass, and its acceleration. </span>...</p>
 </note>
 
 ####Teacher Misconception Alert

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ If a text feature (`fun-in-physics`, `work-in-physics`, `boundless-physics`, `li
 <note class="ost-interactive virtual-physics ost-tag-lo-k12phys-ch12-s01-lo04">
   <label>Virtual Physics</label>
   ...
-  <media ... iframe width="" height="" class="os-embed" src="..." />
+  <media alt=“…” class=“os-embed><iframe width=“960” height=“785” src=“…”/></media>
   ...
 </note>
 
@@ -216,7 +216,7 @@ If a text feature (`fun-in-physics`, `work-in-physics`, `boundless-physics`, `li
 <note class="ost-assessed-feature ost-interactive virtual-physics ost-tag-lo-k12phys-ch12-s01-lo04">
   <label>Virtual Physics</label>
   ...
-  <iframe class="os-embed" src="..." />
+  <media alt=“…” class=“os-embed><iframe width=“960” height=“785” src=“…”/></media>
   ...
   <exercise class=“os-exercise grasp-check”>
   <label>Grasp Check</label>

--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@
   - `ost-exercise-choice` : Used for a group of exercises which will be used in the i-reading, but will be pre-processed by Tutor first. Only occurs on `practice-problems` right now. 
   - `ost-reading-discard` : On `snap-lab` and end of section and chapter items, including `key-equations` `key-terms` `glossary` `summary`  `practice-concepts` `chapter-review` (and its variants( `test prep` (and its variants)
   - `ost-assignable`: Only on `snap-lab`s and `chapter-review performance`
-  - `ost-teks-def` : Place on the text of the TEKS in teacher-content that tells what that TEKS addresses
   - `ost-learning-objective-def` : Place on the learning objective text that defines the LO 
-  - `ost-ngss-def` : Place on the Next Generation Science Standards (NGSS) text that defines the NGSS. Only occurs on Performance Task.
+  - `ost-standards-def` : Generic standards definition class. Place on the Next Generation Science Standards (NGSS) and TEKS class that define the TEKS or NGSS name and its definition. Only occurs on a) TS content that defines NGSS (Performance Task) and b) TS content that defines TEKS standards.
+  - `ost-standards-teks` : Specific TEKS definition class. Place on the class that defines the TEKS name and its definition. 
+  - `ost-standards-ngss` : Specific NGSS definition class. Place on the class that defines the TEKS name and its definition. 
+  - `ost-standards-name` : Generic class that defines the TEKS or NGSS name (e.g., 4C or HS-PS2-*). 
+  - `ost-standards-description` : Generic class that defines the TEKS or NGSS text description. 
 - no prefix: visual styling only
 
 
@@ -250,9 +253,20 @@ Notes:
 ```html
 <note class="os-teacher">
   <label>Teacher Edition</label>
-  <p>Students are usually bored by this but the simulation engages them. Try to jump to the sim first</p>
-    <list>
-      <item>(4C) <span class="ost-tag-teks-112-39-c-4c ost-teks-def">analyze and describe accelerated motion in two dimensions using equations, including projectile and circular examples</span></item>
+	<p>The Learning Objectives in this section will help your students master the following TEKS:</p>
+	  <list>
+	   <item>(4) Science concepts. The student knows and applies the laws governing motion in a variety of situations. The     
+	   student is expected to:
+	   </item>
+      <list>
+          <item class="ost-standards-def ost-standards-teks"><span class="ost-standards-name">(4C)</span>: <span   
+           class="ost-standards-description ost-tag-teks-112-39-c-4c">analyze and describe accelerated motion in two dimensions
+           using equations, including projectile and circular examples</span>
+          </item>
+    	    <item class="ost-standards-def ost-standards-teks"><span class="ost-standards-name">(4A)</span>: <span 
+    	     class="ost-standards-description ost-tags-teks-112-39-c-4a"> analyze …</span>
+    	    </item>
+      </list>
     </list>
 </note>
 ```
@@ -265,8 +279,11 @@ Notes:
 
 <note class="os-teacher">
   <label>Teacher Edition</label>
-  <p>NGSS HS-PS2-1:<span class="ost-tag-ngss-k12phys-hs-ps2-1 ost-ngss-def">Students who demonstrate understanding can: Analyze
-  data to support the claim that Newton’s second law of motion describes the mathematical relationship among the net force on a   macroscopic object, its mass, and its acceleration. </span>...</p>
+  <item class="ost-standards-def ost-standards-ngss">
+    <span class="ost-standards-name">NGSS HS-PS2-1</span>: <span class="ost-standards-description 
+    ost-tag-ngss-k12phys-hs-ps2-1">Students who demonstrate understanding can: Analyze data to support the 
+    claim that Newton’s second law of motion describes the mathematical relationship among the net force on a   
+    macroscopic object, its mass, and its acceleration. </span></item>
 </note>
 
 ####Teacher Misconception Alert
@@ -457,7 +474,12 @@ These are all class attributes on various CNXML elements.
   - `ost-reading-discard`
   - `ost-assignable` (always also has `ost-reading-discard`)
   - `ost-learning-objective-def`
-  - `ost-teks-def`
+  - `ost-standards-def` 
+  - `ost-standards-teks`
+  - `ost-standards-ngss`  
+  - `ost-standards-name`
+  - `ost-standards-description` 
+- no prefix: visual styling only
 
 ## Visual-only
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   - `ost-interactive` : On simulations which is `virtual-physics`
   - `ost-exercise-choice` : Used for a group of exercises which will be used in the i-reading, but will be pre-processed by Tutor first. Only occurs on `practice-problems` right now. 
   - `ost-reading-discard` : On `snap-lab` and end of section and chapter items, including `key-equations` `key-terms` `glossary` `summary`  `practice-concepts` `chapter-review` (and its variants( `test prep` (and its variants)
-  - `ost-assignable`: Only on `snap-lab`s. 
+  - `ost-assignable`: Only on `snap-lab`s and `chapter-review performance`
   - `ost-teks-def` : Place on the text of the TEKS in teacher-content that tells what that TEKS addresses
   - `ost-learning-objective-def` : Place on the learning objective text that defines the LO 
   - `ost-ngss-def` : Place on the Next Generation Science Standards (NGSS) text that defines the NGSS. Only occurs on Performance Task.
@@ -102,15 +102,15 @@ Note that for physics, the TEKS tags only appear on the learning objectives or i
 
 ### Text Features
 
-Required classes: one of `fun-in-physics` `work-in-physics` `boundless-physics` `links-to-physics` and `ost-assessed-feature`
+Required classes: one of `fun-in-physics` `work-in-physics` `boundless-physics` `links-to-physics` and `ost-assessed-feature` and ost-tag-lo-k12phys-ch??-s??-lo??
 
-<note class="fun-in-physics ost-assessed-feature">
+<note class="fun-in-physics ost-assessed-feature ost-tag-lo-k12phys-ch12-s01-lo04">
 ...
 </note>
 
 ### Snap Lab
 
-Required classes: `snap-lab ost-assignable ost-assessed-feature ost-reading-discard`
+Required classes: `snap-lab ost-assignable ost-assessed-feature ost-reading-discard`ost-tag-lo-k12phys-ch??-s??-lo??
 
 Optional classes:
 
@@ -118,7 +118,7 @@ Optional classes:
 - `students-1`, `students-2`, `students-group`
 
 ```html
-<note class="ost-assignable ost-reading-discard ost-assessed-feature snap-lab students-1">
+<note class="ost-assignable ost-reading-discard ost-assessed-feature snap-lab students-? ost-tag-lo-k12phys-ch??-s??-lo??">
   <label>Snap Lab</label>
   <title>...</title>
   ...
@@ -152,7 +152,7 @@ Optional classes:
 When there is more than one worked example, multiple examples will live in the same container and will not be converted to a separate step. We add a class that includes the ExerciseID for the Worked Example's multiple-choice "clone" in Exercises.
 
 ```html
-<note class="ost-feature worked-example">
+<note class="ost-feature worked-example ost-tag-lo-k12phys-ch12-s01-lo04">
   <label>Worked Example</label>
   <exercise class="ost-k12phys-ch04-ex034">
     <title>...</title>
@@ -163,7 +163,7 @@ When there is more than one worked example, multiple examples will live in the s
 </note>
 
 
-<note class="ost-feature worked-examples">
+<note class="ost-feature worked-examples ost-tag-lo-k12phys-ch12-s01-lo04">
   <label>Worked Examples</label>
   <exercise class="ost-k12phys-ch04-ex035">
     <title>...</title>
@@ -188,7 +188,7 @@ If a text feature (`fun-in-physics`, `work-in-physics`, `boundless-physics`, `li
 
 ```html
 
-<note class="ost-assessed-feature ost-video watch-physics">
+<note class="ost-assessed-feature ost-video watch-physics ost-tag-lo-k12phys-ch12-s01-lo04">
   <label>Watch Physics</label>
   <title>Calculating Average Velocity or Speed</title>
   <p>This <a class="os-embed" href="https://youtube.com/watch?askjdh">video</a> reviews vectors...</p>
@@ -205,7 +205,7 @@ If a text feature (`fun-in-physics`, `work-in-physics`, `boundless-physics`, `li
 
 ```html
 <!-- Without a grasp check -->
-<note class="ost-interactive virtual-physics">
+<note class="ost-interactive virtual-physics ost-tag-lo-k12phys-ch12-s01-lo04">
   <label>Virtual Physics</label>
   ...
   <media ... iframe width="" height="" class="os-embed" src="..." />
@@ -213,7 +213,7 @@ If a text feature (`fun-in-physics`, `work-in-physics`, `boundless-physics`, `li
 </note>
 
 <!-- With a grasp check -->
-<note class="ost-assessed-feature ost-interactive virtual-physics">
+<note class="ost-assessed-feature ost-interactive virtual-physics ost-tag-lo-k12phys-ch12-s01-lo04">
   <label>Virtual Physics</label>
   ...
   <iframe class="os-embed" src="..." />
@@ -469,8 +469,8 @@ These are all class attributes on various CNXML elements.
   - `students-2`
   - `students-group`
   - `safety-warning`
-- `example-problem`
-- `example-problems`
+- `worked-example`
+- `worked-examples`
 - `key-terms`
 - Videos
   - `watch-physics`

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Notes:
 
 ```html
 <note class="teacher-demonstration">
-  <label>Demonstration</label>
+  <label>Teacher Demonstration</label>
   ...
 </note>
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
   - `ost-standards-ngss` : Specific NGSS definition class. Place on the class that defines the TEKS name and its definition. 
   - `ost-standards-name` : Generic class that defines the TEKS or NGSS name (e.g., 4C or HS-PS2-*). 
   - `ost-standards-description` : Generic class that defines the TEKS or NGSS text description. 
+  - `ost-standards-discard`: Generic class that lets UX style (i.e., remove) the : listed in the TEKS and NGSS standards
 - no prefix: visual styling only
 
 
@@ -259,12 +260,11 @@ Notes:
 	   student is expected to:
 	   </item>
       <list>
-          <item class="ost-standards-def ost-standards-teks"><span class="ost-standards-name">(4C)</span>: <span   
-           class="ost-standards-description ost-tag-teks-112-39-c-4c">analyze and describe accelerated motion in two dimensions
-           using equations, including projectile and circular examples</span>
+          <item class="ost-standards-def ost-standards-teks"><span class="ost-standards-name">(4C)</span><span 		
+          class="ost-standards-discard">:</span> <span class="ost-standards-description ost-tag-teks-112-39-c-4c">analyze and 
+          describe accelerated motion in two dimensions using equations, including projectile and circular examples</span>
           </item>
-    	    <item class="ost-standards-def ost-standards-teks"><span class="ost-standards-name">(4A)</span>: <span 
-    	     class="ost-standards-description ost-tags-teks-112-39-c-4a"> analyze …</span>
+    	    <item class="ost-standards-def ost-standards-teks"><span class="ost-standards-name">(4A)</span><span 		             class="ost-standards-discard">:</span> <span class="ost-standards-description ost-tags-teks-112-39-c-4a"> analyze 	     …</span>
     	    </item>
       </list>
     </list>
@@ -280,9 +280,8 @@ Notes:
 <note class="os-teacher">
   <label>Teacher Edition</label>
   <item class="ost-standards-def ost-standards-ngss">
-    <span class="ost-standards-name">NGSS HS-PS2-1</span>: <span class="ost-standards-description 
-    ost-tag-ngss-k12phys-hs-ps2-1">Students who demonstrate understanding can: Analyze data to support the 
-    claim that Newton’s second law of motion describes the mathematical relationship among the net force on a   
+    <span class="ost-standards-name">NGSS HS-PS2-1</span><span class="ost-standards-discard">:</span> <span 		
+    class="ost-standards-description ost-tag-ngss-k12phys-hs-ps2-1">Students who demonstrate understanding can: Analyze data to     support the claim that Newton’s second law of motion describes the mathematical relationship among the net force on a   
     macroscopic object, its mass, and its acceleration. </span></item>
 </note>
 
@@ -478,7 +477,8 @@ These are all class attributes on various CNXML elements.
   - `ost-standards-teks`
   - `ost-standards-ngss`  
   - `ost-standards-name`
-  - `ost-standards-description` 
+  - `ost-standards-description`
+  - `ost-standards-discard` 
 - no prefix: visual styling only
 
 ## Visual-only

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Note that for physics, the TEKS tags only appear on the learning objectives or i
 
 ### Text Features
 
-Required classes: one of `fun-in-physics` `work-in-physics` `boundless-physics` `links-to-physics` and `ost-assessed-feature` and ost-tag-lo-k12phys-ch??-s??-lo??
+Required classes: one of `fun-in-physics` `work-in-physics` `boundless-physics` `links-to-physics` and `ost-assessed-feature` and `ost-tag-lo-k12phys-ch??-s??-lo??`
 
 <note class="fun-in-physics ost-assessed-feature ost-tag-lo-k12phys-ch12-s01-lo04">
 ...
@@ -110,7 +110,7 @@ Required classes: one of `fun-in-physics` `work-in-physics` `boundless-physics` 
 
 ### Snap Lab
 
-Required classes: `snap-lab ost-assignable ost-assessed-feature ost-reading-discard`ost-tag-lo-k12phys-ch??-s??-lo??
+Required classes: `snap-lab ost-assignable ost-assessed-feature ost-reading-discard``ost-tag-lo-k12phys-ch??-s??-lo??`
 
 Optional classes:
 


### PR DESCRIPTION
- Revised the title tag for Test Prep from Multiple Choice to Test Prep Multiple Choice. We need to include Test Prep in the title tag for all Test Prep question (multiple choice, short answer, extended response). 
- W&N will add NGSS (Next Generation Science Standards) tags to chapter-review-performance items. These standards are defined externally to Tutor, and teachers will see them in TS content. To make sure they can be treated similarly to LO's, I added
  ost-tag-ngss-k12phys-\* for NGSS items and ost-ngss-def class on the corresponding TS (see changes to Conventions, Performance Task example, and Teacher Content with NGSS example)
- Added documentation to explain Chapter Review and Test Prep <title> tags
